### PR TITLE
Bump max_user_watches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,5 +13,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: npm install
       - run: make test


### PR DESCRIPTION
Jenkins tests are getting stuck due to a limit on max_user_watches.Bumping the max_user_watches as done here https://github.com/ccnmtl/stats-interactives/pull/877